### PR TITLE
Update blue_iris_api.py

### DIFF
--- a/custom_components/blueiris/api/blue_iris_api.py
+++ b/custom_components/blueiris/api/blue_iris_api.py
@@ -139,7 +139,7 @@ class BlueIrisApi:
             )
 
     async def async_update(self):
-        _LOGGER.info(
+        _LOGGER.debug(
             f"Updating data from BI Server ({self.config_manager.config_entry.title})"
         )
 


### PR DESCRIPTION
The logs of this integration can become fairly verbose with relatively useless information. This pull request changes the message of "updating data from BI Server" from an info message to a debug message. This message typically happens every 30 seconds, so no need for it to be an info message.

